### PR TITLE
fix: bundle update failure

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -22,6 +22,7 @@ rbenv global $(cat ~/live/.ruby-version)
 cd ~/live
 gem update --system
 gem install bundler:1.17.3
+bundle update
 bundle install 
 sudo yarn install 
 


### PR DESCRIPTION
$ bundle install
Fetching gem metadata from https://rubygems.org/.........
You have requested:
  nokogiri ~> 1.11

The bundle currently has nokogiri locked at 1.10.10.
Try running `bundle update nokogiri`

If you are updating multiple gems in your Gemfile at once,
try passing them all to `bundle update`